### PR TITLE
Package has some missing dependencies, and doesn't work unless elixir.config.images is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ Elixir.extend('images', function(src, output, options) {
             stats: false,
             silent: true
         }
-    }, config.images);
+    }, config.images || {});
 
     options = {
         responsive: options && options.responsive || config.images.responsive,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "gulp-changed": "^1.3.0",
     "gulp-filter": "^4.0.0",
+    "gulp-if": "^2.0.1",
     "gulp-responsive": "^2.2.0",
     "imagemin-giflossy": "^1.0.0-rc2",
     "imagemin-gifsicle": "^4.2.0",
@@ -35,6 +36,8 @@
     "imagemin-pngquant": "^4.2.2",
     "imagemin-svgo": "^4.2.1",
     "imagemin-webp": "^3.1.1",
-    "lazypipe": "^1.0.1"
+    "lazypipe": "^1.0.1",
+    "underscore": "^1.8.3",
+    "underscore-deep-extend": "^1.1.5"
   }
 }


### PR DESCRIPTION
`elixir.config.images` isn't mentioned in the documentation, so I think the extension should work whether it is defined or not.

Also the extension didn't work for me initially because my project doesn't include `gulp-if`, `underscore` or `underscore-deep-extend`. They should be declared as dependencies of `laravel-elixir-images`.
