### PR TITLE
Add `optimize` option to enable imagemin during non-production builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ Elixir.extend('images', function(src, output, options) {
         sizes: [[], [1200], [992], [768], [544]],
         webp: true,
         lossy: false,
+        optimize: false,
         extensions: {
             lossy: {
                 gif: {
@@ -206,7 +207,7 @@ Elixir.extend('images', function(src, output, options) {
             .src(paths.src.path)
             .pipe($.if(!config.production, $.changed(paths.output.baseDir)))
             .pipe(responsivePipe())
-            .pipe($.if(config.production, imageminPipe()))
+            .pipe($.if(config.images.optimize || config.production, imageminPipe()))
             .pipe(gulp.dest(paths.output.baseDir))
             .pipe(new Elixir.Notification('Images Compiled!'))
         ;

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Use it like this:
 gulp images
 ```
 
-The `--production` flag will engage image optimization in addition to resizing. Works with `gulp watch`, too.
+The `--production` flag, or the `optimize` option, will engage image optimization in addition to resizing. Works with `gulp watch`, too.
 
 ## Installation
 


### PR DESCRIPTION
I prefer to enable imagemin during development, which wasn't possible without adding a new option. I'm using it like this:

``` javascript
elixir.config.images = elixir.config.images || {};
elixir.config.images.optimize = true;
```

but it can also be passed as part of the third parameter as indicated in the README.
